### PR TITLE
adapter: Fix option parsing

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -245,7 +245,7 @@ class NetworkAdapter:
                 for key in options.keys():
                     if key == 'name':
                         self.setName(options[key])
-                    if key == 'addrFam':
+                    elif key == 'addrFam':
                         self.setAddrFam(options[key])
                     elif key == 'source':
                         self.setAddressSource(options[key])

--- a/toolutils.py
+++ b/toolutils.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 from contextlib import contextmanager
 import subprocess
 
@@ -27,9 +26,12 @@ def atomic_write(filepath):
         :param filepath: the file path to be opened
     """
 
-    with tempfile.NamedTemporaryFile() as tf:
+    # Put tmp file to same directory as target file, to allow atomic move
+    realpath = os.path.realpath(filepath)
+    tmppath = os.path.dirname(realpath)
+    with tempfile.NamedTemporaryFile(dir=tmppath, delete=False) as tf:
         with open(tf.name, mode='w+') as tmp:
             yield tmp
             tmp.flush()
             os.fsync(tmp.fileno())
-        shutil.copy(tf.name, filepath)
+        os.rename(tf.name, realpath)


### PR DESCRIPTION
name ended up as a unknown option due to not being part of the if/elif block.

Signed-off-by: Julian Scheel julian@jusst.de
